### PR TITLE
inode_num fix

### DIFF
--- a/src/include/fat32.h
+++ b/src/include/fat32.h
@@ -27,6 +27,7 @@ struct fat32_file {
     uint64_t dir_cluster_addr;
     uint64_t inode_sector;
     uint64_t inode_offset;
+    uint64_t inode_num;
     uint32_t size;
     time_t crtime;
     time_t latime;


### PR DESCRIPTION
Provides a unique inode_num to each file in a FAT32 file system by traversing the file system tree in depth-first order.