### PR TITLE
fat32: diff compatible

### DIFF
--- a/src/gray-crawler/fat32/fat32.c
+++ b/src/gray-crawler/fat32/fat32.c
@@ -245,7 +245,13 @@ char* read_name_long_entry(unsigned char* entry)
         {
             idx = 2 * (i - 11) + 28;
         }
-        memcpy(name + i, entry + idx, 1);
+        char fst_byte = *(entry + idx + 1);
+        //char ninth_bit = *(entry + idx) >> 7;
+        if (fst_byte) {
+          *(name + i) = 0x3F;
+        } else {
+          memcpy(name + i, entry + idx, 1);
+        }
         if (!*(entry + idx)) break;
     }
     return name;

--- a/src/gray-crawler/fat32/fat32.c
+++ b/src/gray-crawler/fat32/fat32.c
@@ -227,7 +227,7 @@ uint32_t get_fat_entry(int disk, int cluster_num, struct fs* fs) {
     return result;
 }
 
-char* read_name_long_entry(unsigned char* entry) 
+char* read_name_long_entry(unsigned char* entry)
 {
     char *name = calloc(1, 14);
     int idx; int i;
@@ -235,7 +235,7 @@ char* read_name_long_entry(unsigned char* entry)
     {
         if (i < 5)
         {
-            idx = 2 * i + 1;
+            idx = (2 * i) + 1;
         }
         else if (i < 11)
         {
@@ -245,7 +245,6 @@ char* read_name_long_entry(unsigned char* entry)
         {
             idx = 2 * (i - 11) + 28;
         }
-
         memcpy(name + i, entry + idx, 1);
         if (!*(entry + idx)) break;
     }
@@ -314,6 +313,56 @@ void fill_tm_from_fat32_datestamp(struct tm* result, uint16_t fat32_date)
     result->tm_mon = (int) (month - 1);
     result->tm_year = (1980 + (int) year) - 1900;
     result->tm_isdst = -1;
+}
+
+void remove_trailing_spaces(char* str) {
+  int len = strlen(str); int last_space = 0;
+  int i;
+  bool seen_space = false;
+  for (i = 0; i < len; i++) {
+    if (str[i] == 0x20 && !seen_space) {
+      seen_space = true;
+      last_space = i;
+    } else if (str[i] != 0x20) {
+      seen_space = false;
+    }
+  }
+  if (seen_space) str[last_space] = 0;
+}
+
+void remove_leading_spaces(char* str) {
+  int i, len = strlen(str);
+  for (i = 0; i < len; i++) {
+    if (str[i] != 0x2e) {
+      break;
+    }
+    str++;
+  }
+}
+
+bool is_empty_extension(char* ext) {
+  return !strcmp(ext, "   ");
+}
+
+bool is_dot_or_dotdot_entry(struct fat32_file* file_info) {
+  return !strcmp(file_info->name, ".") || !strcmp(file_info->name, "..");
+}
+
+char* convert_short_filename(char* short_filename) {
+  char* extension = short_filename + 8;
+  char* name = calloc(1, 9); char* full_name;
+  memcpy(name, short_filename, 8);
+  extension = short_filename + 8;
+  remove_trailing_spaces(name);
+  if (!is_empty_extension(extension)) {
+    remove_trailing_spaces(extension);
+    full_name = calloc(1, 2 + strlen(extension) + strlen(name));
+    strcpy(full_name, name);
+    *(full_name + strlen(name)) = '.';
+    strcpy(full_name + strlen(name) + 1, extension);
+    return full_name;
+  } 
+  return name;
 }
 
 void print_file_info(struct fat32_file* file_info) {
@@ -455,7 +504,7 @@ int fat32_serialize_file_info(struct fs* fs, int disk, struct fat32_file* file,
     if (file->is_dir) {
       mode = S_IFDIR | 0755;
     } else {
-      mode = S_IFREG | 0444;
+      mode = S_IFREG | 0755;
     }
 
     value.type = BSON_INT64; 
@@ -562,7 +611,7 @@ int read_dir_cluster(char* path, int disk, uint32_t cluster_num,
     struct fat32_volumeID* volID = fs->fs_info;
     char* long_name = NULL;
     struct fat32_file file_info = {0};
-    static uint64_t inode_num = 2; //root is zero, root_dot is one
+    static uint64_t inode_num = 1; //root is zero, root_dot is one
     if (lseek64(disk, (off64_t) (cluster_addr), SEEK_SET) == (off64_t) -1)
     {
         fprintf_light_red(stderr, "Failed seeking to cluster_addr: "
@@ -629,14 +678,17 @@ int read_dir_cluster(char* path, int disk, uint32_t cluster_num,
             if (long_name) 
             {
                 file_info.name = long_name;
+                remove_trailing_spaces(file_info.name);
                 long_name = NULL;
             }
             else 
             {
-                file_info.name = short_name;
+                file_info.name = convert_short_filename(short_name);
                 hexdump((uint8_t*)short_name, strlen(short_name));
-                printf("NO LONG NAME\n");
+                printf("NO LONG NAME %s\n", file_info.name);
             }
+
+            
             file_info.inode_num = inode_num;
             inode_num++;
             uint8_t crtime_tenth = *((uint8_t*) (entry + 13));
@@ -690,9 +742,10 @@ int read_dir_cluster(char* path, int disk, uint32_t cluster_num,
                 file_info.is_dir = false;
                 print_file_info(&file_info);
             }
-
-            fat32_serialize_file_info(fs, disk, &file_info, serializef,
+            if (!is_dot_or_dotdot_entry(&file_info)) {
+              fat32_serialize_file_info(fs, disk, &file_info, serializef,
                                       prev_dir_files, cur_dir_files);
+            }
             free_file_info(&file_info);
             fat32_reset_file_info(&file_info);
         }
@@ -832,13 +885,13 @@ int fat32_serialize(int disk, struct fs* fs, int serializef)
     root.cluster_num = 2;
     root.path = "/";
 
-    struct fat32_file root_dot = {0};
+    /*struct fat32_file root_dot = {0};
     root_dot.name = ".";
     root_dot.path = "/.";
     root_dot.is_dir = true;
     root_dot.cluster_num = 2;
     root_dot.inode_num = 1;
-    root_dot.inode_sector = get_cluster_addr(fs, 2) / SECTOR_SIZE;
+    root_dot.inode_sector = get_cluster_addr(fs, 2) / SECTOR_SIZE;*/
 
     /* serialize root file system depth-first */
     if (read_dir_cluster("", disk, 2, fs, root_files, serializef))
@@ -846,7 +899,7 @@ int fat32_serialize(int disk, struct fs* fs, int serializef)
         fprintf_light_red(stderr, "Error reading dir cluster 2.\n");
         return -1;
     }
-    fat32_serialize_file_info(fs, disk, &root_dot, serializef, root_files, NULL);
+    //fat32_serialize_file_info(fs, disk, &root_dot, serializef, root_files, NULL);
     fat32_serialize_file_info(fs, disk, &root, serializef, NULL, root_files);
 
     return 0;

--- a/src/gray-crawler/fat32/fat32.c
+++ b/src/gray-crawler/fat32/fat32.c
@@ -26,6 +26,7 @@
 
 #include <sys/types.h>
 
+#include <fcntl.h>
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -374,143 +375,6 @@ void fat32_reset_file_info(struct fat32_file* file_info)
     file_info->lwtime = 0;
 }
 
-int fat32_get_dir_entries(char* path, int disk, uint32_t cluster_num,
-                          struct fs* fs, int serializef, uint64_t inode_num,
-                          struct bson_info* files)
-{
-    uint64_t cluster_addr = get_cluster_addr(fs, cluster_num);
-    int offset = 0;
-    unsigned char* entry = calloc(1, 32); 
-    struct fat32_volumeID* volID = fs->fs_info;
-    char* long_name = NULL;
-    struct fat32_file file_info = {0};
-    off64_t curr_offset = lseek64(disk, 0, SEEK_CUR);
-    char dentry_key[32];
-    struct bson_kv dentry;
-    uint8_t file_entry_buf[4096 + sizeof(uint64_t)];
-
-    if (lseek64(disk, (off64_t) (cluster_addr), SEEK_SET) == (off64_t) -1)
-    {
-        fprintf_light_red(stderr, "Failed seeking to cluster_addr: "
-                                  "%"PRIu64"\n", (uint64_t) cluster_addr);
-        return -1;
-    }
-
-    snprintf(dentry_key, 32, "%"PRIu64, cluster_addr);
-    dentry.key = dentry_key;
-    dentry.type = BSON_BINARY;
-    dentry.data = file_entry_buf;
-
-    while (true) 
-    {
-        if (read(disk, (void*)entry, 32) != 32)
-        {
-            fprintf_light_red(stderr, "Error while trying to read record.\n");
-            return -1;
-        }
-
-        offset += 32;
-
-        if (!(entry[0] ^ (unsigned char) 0xe5))
-        {
-            // This entry is empty.
-            continue;
-        }
-
-        if (!entry[0]) 
-        {
-            // No more directory entries.
-            break;
-        }
-
-        if (!(entry[11] ^ (unsigned char) 0x08))
-        {
-            // This entry is the volume id.
-            continue;
-        }
-
-        if (!(entry[11] ^ (unsigned char) 0xF)) 
-        {
-            char* entry_name = read_name_long_entry(entry);
-
-            if (!long_name) 
-            {
-                long_name = entry_name;
-            }
-            else 
-            {
-                char* temp = long_name;
-                long_name = calloc(1, strlen(temp) + strlen(entry_name) + 1);
-                strcpy(long_name, entry_name); strcat(long_name, temp);
-            }
-        } 
-        else 
-        {
-            char* short_name = read_short_entry(entry);
-
-            if (long_name) 
-            {
-                file_info.name = long_name;
-                long_name = NULL;
-            }
-            else 
-            {
-                file_info.name = short_name;
-            }
-
-            file_info.path = make_path_name(path, file_info.name);
-
-            fprintf_light_white(stdout, "---> file: %s\n", file_info.path);
-            
-            inode_num++;
-            memcpy(file_entry_buf, &inode_num, sizeof(uint64_t));
-            memcpy(&(file_entry_buf[sizeof(uint64_t)]), file_info.path,
-                   strlen(file_info.path));
-            dentry.size = sizeof(uint64_t) + strlen(file_info.path);
-            bson_serialize(files, &dentry);
-
-            if ((entry[11] & (unsigned char)0x10) && entry[0] ^
-                (unsigned char)0x2E)  
-            {
-                file_info.is_dir = true;
-                lseek64(disk, (off64_t) (cluster_addr + offset), SEEK_SET);
-            }
-            else
-            {
-                file_info.is_dir = false;
-            }
-
-            free_file_info(&file_info);
-            fat32_reset_file_info(&file_info);
-        }
-
-        if (offset == SECTOR_SIZE * volID->sectors_per_cluster) 
-        {
-            uint32_t fat_entry = get_fat_entry(disk, cluster_num, fs);
-
-            if (fat_entry == FAT32_EOC) 
-            {
-                printf("End of Directory! (fat_entry) \n");
-                return 0;
-            }
-            cluster_num = fat_entry;
-            printf("fat_entry %" PRIu32 "\n", fat_entry);
-            cluster_addr = get_cluster_addr(fs,fat_entry);
-            printf("cluster_addr %" PRId64 "\n", cluster_addr);
-            offset = 0;
-            lseek64(disk, (off64_t) (cluster_addr), SEEK_SET);
-            snprintf(dentry_key, 32, "%"PRIu64, cluster_addr);
-        }
-    }
-
-    free(entry);
-
-    /* defensively set offset back */
-    lseek64(disk, curr_offset, SEEK_SET);
-
-    return 0;
-}
-
 int fat32_serialize_file_info(struct fs* fs, int disk, struct fat32_file* file, 
                               int serializef, struct bson_info* prev_dir_files,
                               struct bson_info* cur_dir_files)
@@ -525,7 +389,7 @@ int fat32_serialize_file_info(struct fs* fs, int disk, struct fat32_file* file,
 
     uint64_t counter = 0;
     uint64_t cluster_num = file->cluster_num;
-    uint64_t cluster_addr = get_cluster_addr(fs, file->cluster_num);
+    //uint64_t cluster_addr = get_cluster_addr(fs, file->cluster_num);
     uint64_t cluster_sector = 0;
     uint64_t inode_sector = file->inode_sector;
     uint64_t inode_offset = file->inode_offset;
@@ -588,6 +452,12 @@ int fat32_serialize_file_info(struct fs* fs, int disk, struct fat32_file* file,
     value.data = &size;
 
     bson_serialize(serialized, &value);
+
+    if (file->is_dir) {
+      mode = S_IFDIR | 0755;
+    } else {
+      mode = S_IFREG | 0444;
+    }
 
     value.type = BSON_INT64; 
     value.key = "mode";
@@ -655,13 +525,13 @@ int fat32_serialize_file_info(struct fs* fs, int disk, struct fat32_file* file,
     bson_serialize(serialized, &value);
 
     if (prev_dir_files != NULL) {
-      snprintf(dentry_key, 32, "%"PRIu64, cluster_addr);
+      snprintf(dentry_key, 32, "%"PRIu64, inode_sector);
       dentry.key = dentry_key;
       dentry.type = BSON_BINARY;
       dentry.data = file_entry_buf;
-      dentry.size = sizeof(uint64_t) + strlen(file->path);
+      dentry.size = sizeof(uint64_t) + strlen(file->name);
       memcpy(file_entry_buf, &inode_num, sizeof(uint64_t));
-      memcpy(&(file_entry_buf[sizeof(uint64_t)]), file->path, strlen(file->path));
+      memcpy(&(file_entry_buf[sizeof(uint64_t)]), file->name, strlen(file->name));
       bson_serialize(prev_dir_files, &dentry);
     }
 
@@ -693,7 +563,7 @@ int read_dir_cluster(char* path, int disk, uint32_t cluster_num,
     struct fat32_volumeID* volID = fs->fs_info;
     char* long_name = NULL;
     struct fat32_file file_info = {0};
-    static uint64_t inode_num = 1; //root is zero
+    static uint64_t inode_num = 2; //root is zero, root_dot is one
 
     if (lseek64(disk, (off64_t) (cluster_addr), SEEK_SET) == (off64_t) -1)
     {
@@ -963,12 +833,22 @@ int fat32_serialize(int disk, struct fs* fs, int serializef)
     root.inode_num = 0;
     root.cluster_num = 2;
     root.path = "/";
+
+    struct fat32_file root_dot = {0};
+    root_dot.name = ".";
+    root_dot.path = "/.";
+    root_dot.is_dir = true;
+    root_dot.cluster_num = 2;
+    root_dot.inode_num = 1;
+    root_dot.inode_sector = get_cluster_addr(fs, 2) / SECTOR_SIZE;
+
     /* serialize root file system depth-first */
     if (read_dir_cluster("", disk, 2, fs, root_files, serializef))
     {
         fprintf_light_red(stderr, "Error reading dir cluster 2.\n");
         return -1;
     }
+    fat32_serialize_file_info(fs, disk, &root_dot, serializef, root_files, NULL);
     fat32_serialize_file_info(fs, disk, &root, serializef, NULL, root_files);
 
     return 0;

--- a/src/gray-fs/gray-fs.c
+++ b/src/gray-fs/gray-fs.c
@@ -270,14 +270,14 @@ int main(int argc, char* argv[])
     fd_disk = open(path, O_RDONLY);
     argc -= 1;
 
-    if (redis_hash_field_get(handle, REDIS_SUPERBLOCK_SECTOR_GET, 0,
+    if (redis_hash_field_get(handle, REDIS_SUPERBLOCK_SECTOR_GET, 1,
                              "block_size", (uint8_t*) &block_size, &len))
         return -ENOENT;
 
     if (len != 8)
         return EXIT_FAILURE;
 
-    if (qemu_get_pt_offset(handle, &partition_offset, (uint64_t) 0))
+    if (qemu_get_pt_offset(handle, &partition_offset, (uint64_t) 1))
         return EXIT_FAILURE;
 
     return fuse_main(argc, argv, &gammarayfs_oper, NULL);

--- a/src/gray-fs/gray-fs.c
+++ b/src/gray-fs/gray-fs.c
@@ -192,7 +192,7 @@ static int gammarayfs_read(const char* path, char* buf, size_t size,
                            off_t offset, struct fuse_file_info* fi)
 {
     uint64_t inode_num = gammarayfs_pathlookup(path), position = 0,
-             i = 0, start = offset / 4096, end;
+             i = 0, start = offset / block_size, end;
     int64_t sector = 0;
     uint8_t** list;
     size_t len = 0;

--- a/src/include/fat32.h
+++ b/src/include/fat32.h
@@ -27,6 +27,7 @@ struct fat32_file {
     uint64_t dir_cluster_addr;
     uint64_t inode_sector;
     uint64_t inode_offset;
+    uint64_t inode_num;
     uint32_t size;
     time_t crtime;
     time_t latime;


### PR DESCRIPTION
- fat32 is now diff compatible with the Linux read functionality for fat32
- gray-fs now properly divides by a dynamic `block_size` rather than a hard-coded value
